### PR TITLE
Add Google Places-powered landmarks endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,3 +3,50 @@
 - `src/`: API 라우터, 서비스, 데이터베이스 모듈 등 서버 사이드 코드를 배치합니다.
 
 백엔드는 `shared/contracts` 디렉터리를 참조하여 프론트엔드와 합의한 API 스펙을 구현하고 버전을 맞춥니다.
+
+## 개발 서버 실행하기
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+기본적으로 3001 포트에서 Express 서버가 구동되며 `/api/landmarks` 엔드포인트를 제공합니다.
+
+## `/api/landmarks`
+
+선택한 지도 영역을 기준으로 구글 플레이스 API에서 명소 정보를 조회합니다. 프론트엔드는 지역 이름과 함께 지도 축척(줌 레벨)을 전달하면, 축척에 따라 반경을 계산하여 주변 명소를 반환합니다.
+
+| Query | 설명 | 필수 |
+| --- | --- | --- |
+| `region` | 사용자에게 표시된 지역 이름 | ✅ |
+| `scale` | 지도 축척 또는 줌 레벨(숫자) | ❌ |
+| `latitude` | 지역 중심 위도 | ❌ |
+| `longitude` | 지역 중심 경도 | ❌ |
+
+위/경도가 전달되면 `nearbysearch` API를 사용하고, 그렇지 않은 경우 `textsearch` API를 사용해 명소를 검색합니다.
+
+응답 예시는 아래와 같습니다.
+
+```json
+{
+  "region": "Seoul",
+  "scale": 12,
+  "source": "google_places",
+  "landmarks": [
+    {
+      "placeId": "...",
+      "name": "Gyeongbokgung Palace",
+      "formattedAddress": "161 Sajik-ro, Sejongno, Jongno-gu, Seoul, South Korea",
+      "location": { "lat": 37.5796, "lng": 126.977 },
+      "rating": 4.6,
+      "userRatingsTotal": 92000,
+      "types": ["tourist_attraction", "point_of_interest", "establishment"],
+      "photoReferences": ["Aaw..."]
+    }
+  ]
+}
+```
+
+> **참고:** 실 서비스에서는 `GOOGLE_MAPS_API_KEY` 환경변수에 실제 키를 주입해야 합니다. 현재 레포지토리에는 임시 키(`DUMMY_GOOGLE_MAPS_API_KEY`)가 기본값으로 설정되어 있습니다.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "asymmetry-backend",
+  "version": "0.1.0",
+  "description": "Backend service providing landmark data based on map selections.",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.17",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/routes/landmarks.ts
+++ b/backend/src/routes/landmarks.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import { fetchLandmarksFromGoogle } from '../services/googlePlacesService';
+import type { LandmarksResponse } from '../types/landmark';
+
+export const landmarksRouter = express.Router();
+
+landmarksRouter.get('/', async (req, res) => {
+  const { region, scale, latitude, longitude } = req.query;
+
+  if (typeof region !== 'string' || region.trim().length === 0) {
+    res.status(400).json({ message: 'Query parameter "region" is required.' });
+    return;
+  }
+
+  const parsedScale = typeof scale === 'string' ? Number(scale) : undefined;
+  const parsedLatitude = typeof latitude === 'string' ? Number(latitude) : undefined;
+  const parsedLongitude = typeof longitude === 'string' ? Number(longitude) : undefined;
+
+  try {
+    const landmarks = await fetchLandmarksFromGoogle({
+      region,
+      scale: parsedScale,
+      latitude: parsedLatitude,
+      longitude: parsedLongitude,
+    });
+
+    const responseBody: LandmarksResponse = {
+      region,
+      scale: parsedScale,
+      landmarks,
+      source: 'google_places',
+    };
+
+    res.json(responseBody);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(502).json({
+      message: 'Failed to fetch landmarks from Google Places API',
+      detail: message,
+    });
+  }
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import { landmarksRouter } from './routes/landmarks';
+
+const app = express();
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3001;
+
+app.use(express.json());
+
+app.use('/api/landmarks', landmarksRouter);
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Backend listening on port ${PORT}`);
+});

--- a/backend/src/services/googlePlacesService.ts
+++ b/backend/src/services/googlePlacesService.ts
@@ -1,0 +1,117 @@
+import type { Landmark } from '../types/landmark';
+
+const DEFAULT_GOOGLE_MAPS_API_KEY = 'DUMMY_GOOGLE_MAPS_API_KEY';
+const DEFAULT_MAX_RADIUS = 50000; // meters
+
+interface FetchLandmarksOptions {
+  region: string;
+  latitude?: number;
+  longitude?: number;
+  scale?: number;
+}
+
+interface GooglePlace {
+  place_id: string;
+  name: string;
+  formatted_address?: string;
+  vicinity?: string;
+  geometry?: {
+    location?: {
+      lat?: number;
+      lng?: number;
+    };
+  };
+  rating?: number;
+  user_ratings_total?: number;
+  types?: string[];
+  photos?: Array<{ photo_reference?: string }>;
+}
+
+interface GooglePlacesResponse {
+  results: GooglePlace[];
+  status: string;
+  error_message?: string;
+}
+
+const scaleToRadius = (scale?: number): number | undefined => {
+  if (scale === undefined || Number.isNaN(scale)) {
+    return undefined;
+  }
+
+  const normalizedScale = Math.max(1, Math.min(scale, 20));
+  const exponent = 20 - normalizedScale;
+  const radius = Math.round(Math.min(DEFAULT_MAX_RADIUS, 200 * 2 ** exponent));
+
+  return radius;
+};
+
+const buildRequestUrl = ({
+  region,
+  latitude,
+  longitude,
+  scale,
+}: FetchLandmarksOptions, apiKey: string): string => {
+  const radius = scaleToRadius(scale);
+
+  if (latitude !== undefined && longitude !== undefined) {
+    const searchParams = new URLSearchParams({
+      location: `${latitude},${longitude}`,
+      type: 'tourist_attraction',
+      key: apiKey,
+    });
+
+    if (radius !== undefined) {
+      searchParams.set('radius', radius.toString());
+    }
+
+    return `https://maps.googleapis.com/maps/api/place/nearbysearch/json?${searchParams.toString()}`;
+  }
+
+  const searchParams = new URLSearchParams({
+    query: `${region} tourist attractions`,
+    key: apiKey,
+  });
+
+  if (radius !== undefined) {
+    searchParams.set('radius', radius.toString());
+  }
+
+  return `https://maps.googleapis.com/maps/api/place/textsearch/json?${searchParams.toString()}`;
+};
+
+const transformPlaces = (places: GooglePlace[]): Landmark[] => {
+  return places.map((place) => ({
+    placeId: place.place_id,
+    name: place.name,
+    formattedAddress: place.formatted_address ?? place.vicinity ?? '',
+    location: {
+      lat: place.geometry?.location?.lat ?? 0,
+      lng: place.geometry?.location?.lng ?? 0,
+    },
+    rating: place.rating,
+    userRatingsTotal: place.user_ratings_total,
+    types: place.types,
+    photoReferences: place.photos?.map((photo) => photo.photo_reference ?? '').filter((ref) => ref.length > 0),
+  }));
+};
+
+export const fetchLandmarksFromGoogle = async (
+  options: FetchLandmarksOptions,
+): Promise<Landmark[]> => {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY ?? DEFAULT_GOOGLE_MAPS_API_KEY;
+  const url = buildRequestUrl(options, apiKey);
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Google Places API request failed with status ${response.status}`);
+  }
+
+  const data = (await response.json()) as GooglePlacesResponse;
+
+  if (data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+    throw new Error(`Google Places API returned status ${data.status}: ${data.error_message ?? 'Unknown error'}`);
+  }
+
+  return transformPlaces(data.results ?? []);
+};

--- a/backend/src/types/landmark.ts
+++ b/backend/src/types/landmark.ts
@@ -1,0 +1,20 @@
+export interface Landmark {
+  placeId: string;
+  name: string;
+  formattedAddress: string;
+  location: {
+    lat: number;
+    lng: number;
+  };
+  rating?: number;
+  userRatingsTotal?: number;
+  types?: string[];
+  photoReferences?: string[];
+}
+
+export interface LandmarksResponse {
+  region: string;
+  scale?: number;
+  landmarks: Landmark[];
+  source: 'google_places';
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a TypeScript Express server for the backend
- implement a /api/landmarks route that retrieves tourist attractions from the Google Places API using the provided region, scale, and optional coordinates
- document the endpoint contract and configuration requirements in the backend README

## Testing
- npm install *(fails: 403 Forbidden when downloading @types/express)*

------
https://chatgpt.com/codex/tasks/task_e_68e499102d58832288540b65ae5f50f8